### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+z80ex (1.1.21-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 18:01:04 +0100
+
 z80ex (1.1.21-1) unstable; urgency=low
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Build-Depends: debhelper (>= 9), cmake
 Standards-Version: 3.9.4
 Section: libs
 Homepage: http://z80ex.sourceforge.net/
-Vcs-Git: git://github.com/glaubitz/z80ex-debian.git
+Vcs-Git: https://github.com/glaubitz/z80ex-debian.git
 Vcs-Browser: https://github.com/glaubitz/z80ex-debian
 
 Package: libz80ex-dev


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
